### PR TITLE
Feature - Support multiple Corretto versions

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly CORRETTO_11_BASE_URL="https://corretto.aws/downloads/resources"
+readonly CORRETTO_BASE_URL="https://corretto.aws/downloads/resources"
 
 readonly TMP_DOWNLOAD_DIR="$(mktemp -d)"
 trap 'rm -rf "${TMP_DOWNLOAD_DIR?}"' EXIT
@@ -30,7 +30,7 @@ install() {
   local -r install_type="$1"
   local -r install_version="$2"
   local -r install_path="$3"
-  local -r download_url="${CORRETTO_11_BASE_URL}/${install_version}/amazon-corretto-${install_version}-$(platform).tar.gz"
+  local -r download_url="${CORRETTO_BASE_URL}/${install_version}/amazon-corretto-${install_version}-$(platform).tar.gz"
   local -r download_path="${TMP_DOWNLOAD_DIR}/jdk.tar.gz"
   local -r extracted_path="${TMP_DOWNLOAD_DIR}/extracted"
 

--- a/bin/list-all
+++ b/bin/list-all
@@ -6,10 +6,13 @@ set -o pipefail
 
 : "${GITHUB_API_TOKEN:=""}"
 
-readonly CORRETTO_11_RELEASES_URL="https://api.github.com/repos/corretto/corretto-11/releases"
+CORRETTO_VERSIONS=("8" "11" "17" "20" "21")
 
-#
-# https://github.com/rbenv/ruby-build/blob/ac92ec0507fad718e7abcf13540641937ecfef3f/bin/ruby-build#L1201
+get_corretto_releases_url() {
+  local -r corretto_version="$1"
+  echo "https://api.github.com/repos/corretto/corretto-${corretto_version}/releases"
+}
+
 sort_versions() {
   sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z.\1/; s/$/.z/; G; s/\n/ /' | \
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
@@ -23,6 +26,11 @@ list_github_versions() {
   echo "$(eval $cmd | grep -oE "tag_name\": *\".*\"," | sed "s/tag_name\": *\"//;s/\",//")"
 }
 
-#
-versions="$(list_github_versions "$CORRETTO_11_RELEASES_URL")"
+versions=""
+
+for corretto_version in "${CORRETTO_VERSIONS[@]}"; do
+  corretto_releases_url=$(get_corretto_releases_url "$corretto_version")
+  versions+="$(list_github_versions "$corretto_releases_url") "
+done
+
 echo "$(echo "$versions" | sort_versions | tr '\n' ' ')"


### PR DESCRIPTION
## Background

The current implementation only supports Corretto major version 11. The changes in this PR supports multiple versions.

## Testing
```
$ ./list-all
17.0.8.8.1.z 11.0.5.10.1 11.0.5.10.2 11.0.6.10.1-1 11.0.6.10.1-2 11.0.6.10.1 11.0.7.10.1-1 11.0.7.10.1 11.0.8.10.1 11.0.9.11.1 11.0.9.11.2 11.0.9.12.1 11.0.10.9.1 11.0.11.9.1 11.0.12.7.1 11.0.12.7.2 11.0.13.8.1 11.0.14.9.1 11.0.14.10.1 11.0.15.9.1 11.0.16.8.1 11.0.16.8.3 11.0.16.9.1 11.0.17.8.1 11.0.18.10.1 11.0.18.11.1 11.0.19.7.1 11.0.20.8.1 20.0.2.10.1.z 17.0.0.35.2 17.0.1.12.1 17.0.2.8.1 17.0.3.6.1 17.0.4.8.1 17.0.4.9.1 17.0.5.8.1 17.0.6.10.1 17.0.7.7.1 17.0.8.7.1 21.0.0.35.1.z 20.0.0.36.1 20.0.1.9.1 20.0.2.9.1 .z 11.0.20.9.1.z 8.252.09.1 8.252.09.2 8.262.10.1 8.262.10.2 8.265.01.1 8.265.01.2 8.272.10.1 8.272.10.2 8.272.10.3 8.272.10.4 8.275.01.1 8.275.01.2 8.282.08.1 8.292.10.1 8.292.10.2 8.302.08.1 8.312.07.1 8.322.06.1 8.322.06.2 8.322.06.4 8.332.08.1 8.342.07.1 8.342.07.3 8.342.07.4 8.352.08.1 8.362.08.1 8.362.10.1 8.372.07.1 8.382.05.1 preview-11.0.15.2.1
```

## References
https://github.com/beardix/asdf-java-corretto